### PR TITLE
Email generation future

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ func main() {
 	fmt.Println(k.UserAgent()) // Prints Mozilla/5.0 (compatible; MSIE 5.0; Windows 98; Win 9x 4.90; Trident/4.0)
 	fmt.Println(k.Color()) // Prints Lime #00FF00
 	fmt.Println(k.DateTimeAfter(time.Date(2015, 1, 0, 0, 0, 0, 0, time.UTC))) // Prints 2015-09-08 15:34:29 +0300 EEST
+	fmt.Println(k.Email()) // Prints Jay.Hayden@fakemail.com
 
 }
 ```

--- a/data/en_US/email
+++ b/data/en_US/email
@@ -1,0 +1,2 @@
+{{person_first_name_male}}.{{person_last_name}}@fakemail.com
+{{person_first_name_female}}.{{person_last_name}}@fakemail.com

--- a/email.go
+++ b/email.go
@@ -1,0 +1,12 @@
+package kolpa
+
+// Address function returns a random email address.
+// A convenience function, same as g.GenericGenerator("email"),
+// but only for en_US language
+// Sample Output: Jay.Hayden@fakemail.com
+func (g *Generator) Email() string {
+	if g.Locale_ != "en_US" {
+		g.Locale_ = "en_US"
+	}
+	return g.GenericGenerator("email")
+}

--- a/email_test.go
+++ b/email_test.go
@@ -1,0 +1,19 @@
+package kolpa
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEmail(t *testing.T) {
+	k := C()
+	for _, lang := range getLanguages() {
+		k.SetLanguage(lang)
+
+		email := k.Email()
+		typeOfOutput := reflect.TypeOf(email).Kind()
+		if typeOfOutput != reflect.String {
+			t.Errorf("Email generation is failed for %s.", lang)
+		}
+	}
+}


### PR DESCRIPTION
Why not to add the email generation future?

I have added small function which adds email generation based on en_US languages files, it generates email like {{FirstName}}.{{SecondName}}@fakemail.com