### PR TITLE
Use relative path to locate data files

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -4,12 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"go/build"
 	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -100,10 +98,9 @@ func (g *Generator) formatToSlice(format string) []string {
 func (g *Generator) fileToSlice(fName string) ([]string, error) {
 	var res []string
 
-	_, filePath, _, _:= runtime.Caller(1)
-	path := filepath.Dir(filePath) + "/data/" + g.Locale_ + "/" + fName
+	path := getCurrentDir() + "/data/" + g.Locale_ + "/" + fName
 	file, err := os.Open(path)
-	
+
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +127,7 @@ func (g *Generator) fileToSliceAll(fName string) ([]string, error) {
 	var err error
 	var file *os.File
 
-	path := build.Default.GOPATH + "/src/" + g.Pkg + "/data/" + g.Locale_ + "/"
+	path := getCurrentDir() + "/data/" + g.Locale_ + "/"
 
 	f, err := os.Open(path)
 
@@ -153,7 +150,7 @@ func (g *Generator) fileToSliceAll(fName string) ([]string, error) {
 
 	for _, name := range fNames {
 		file, err = os.Open(path + name)
-		
+
 		if err != nil {
 			return nil, err
 		}
@@ -176,7 +173,6 @@ func (g *Generator) fileToSliceAll(fName string) ([]string, error) {
 	return res, nil
 }
 
-
 // Returns random item from the given string slice.
 func getRandom(options []string) string {
 	rand.Seed(time.Now().UTC().UnixNano())
@@ -191,9 +187,15 @@ func randBool() bool {
 	return parseRandomToBoolean(val)
 }
 
+// getCurrentDir - Get dir path to current file (utils.go)
+func getCurrentDir() string {
+	_, filePath, _, _ := runtime.Caller(1)
+	return filepath.Dir(filePath)
+}
+
 // Returns all possible data for languages.
 func getLanguages() []string {
-	path := os.Getenv("GOPATH") + "/src/" + reflect.TypeOf(Generator{}).PkgPath() + "/data/"
+	path := getCurrentDir() + "/data/"
 	files, _ := ioutil.ReadDir(path)
 	var n string
 	var res []string

--- a/utils.go
+++ b/utils.go
@@ -8,8 +8,10 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -98,7 +100,8 @@ func (g *Generator) formatToSlice(format string) []string {
 func (g *Generator) fileToSlice(fName string) ([]string, error) {
 	var res []string
 
-	path := build.Default.GOPATH + "/src/" + g.Pkg + "/data/" + g.Locale_ + "/" + fName
+	_, filePath, _, _:= runtime.Caller(1)
+	path := filepath.Dir(filePath) + "/data/" + g.Locale_ + "/" + fName
 	file, err := os.Open(path)
 	
 	if err != nil {


### PR DESCRIPTION
The real data files path is something like `/home/zgldh/go/pkg/mod/github.com/malisit/kolpa@v0.0.0-20200926185833-249ff2e89e9a/data/en_US/address_city`
But the `path` was like `/home/zgldh/go/pkg/mod/github.com/malisit/kolpa/data/en_US/address_city` which is not correct.
We should find the real path from the call stack. Please check `getCurrentDir()`

All tests are passed.